### PR TITLE
Add an "R only" layer for mixing R with other runtimes

### DIFF
--- a/awspack/build.sh
+++ b/awspack/build.sh
@@ -16,7 +16,7 @@ BUILD_DIR=${BASE_DIR}/build/
 rm -rf ${BUILD_DIR}
 
 mkdir -p ${BUILD_DIR}/layer/
-docker run -v ${BUILD_DIR}/layer/:/var/awspack -v ${BASE_DIR}/entrypoint.sh:/entrypoint.sh \
+docker run --user $(id -u) -v ${BUILD_DIR}/layer/:/var/awspack -v ${BASE_DIR}/entrypoint.sh:/entrypoint.sh \
     lambda-r:build-${VERSION} /entrypoint.sh
-sudo chown -R $(whoami):$(whoami) ${BUILD_DIR}/layer/
+
 chmod -R 755 ${BUILD_DIR}/layer/

--- a/r/build.sh
+++ b/r/build.sh
@@ -16,6 +16,8 @@ R_DIR=/opt/R/
 
 rm -rf ${BUILD_DIR}
 
-mkdir -p ${BUILD_DIR}/bin/
-docker run -v ${BUILD_DIR}/bin/:/var/r lambda-r:build-${VERSION}
-sudo chown -R $(whoami):$(whoami) ${BUILD_DIR}/bin/
+mkdir -p ${BUILD_DIR}/layer/R/
+docker run --user $(id -u) -v ${BUILD_DIR}/layer/R:/var/r lambda-r:build-${VERSION}
+
+cd ${BUILD_DIR}/layer/
+rm -r R/doc/manual/

--- a/recommended/build.sh
+++ b/recommended/build.sh
@@ -8,7 +8,7 @@ BUILD_DIR=${BASE_DIR}/build/
 rm -rf ${BUILD_DIR}
 mkdir -p ${BUILD_DIR}/layer/R.orig/
 cd ${BUILD_DIR}/layer/
-cp -r ${BASE_DIR}/../r/build/bin/* R.orig/
+cp -r ${BASE_DIR}/../r/build/layer/R/* R.orig/
 mkdir -p R/library
 
 recommended=(boot class cluster codetools foreign KernSmooth lattice MASS Matrix mgcv nlme nnet rpart spatial survival)

--- a/runtime/build.sh
+++ b/runtime/build.sh
@@ -9,8 +9,7 @@ rm -rf ${BUILD_DIR}
 mkdir -p ${BUILD_DIR}/layer/R/
 cp ${BASE_DIR}/src/* ${BUILD_DIR}/layer/
 cd ${BUILD_DIR}/layer/
-cp -r ${BASE_DIR}/../r/build/bin/* R/
-rm -r R/doc/manual/
+cp -r ${BASE_DIR}/../r/build/layer/* .
 #remove some libraries to save space
 recommended=(boot class cluster codetools foreign KernSmooth lattice MASS Matrix mgcv nlme nnet rpart spatial survival)
 for package in "${recommended[@]}"

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,18 @@ Globals:
     Layers:
       - !Ref RuntimeLayer
 Resources:
+  RLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: !Sub r-${Version}
+      ContentUri: r/build/layer/
+      LicenseInfo: MIT
+  RLayerPermission:
+    Type: AWS::Lambda::LayerVersionPermission
+    Properties:
+      Action: lambda:GetLayerVersion
+      LayerVersionArn: !Ref RLayer
+      Principal: "*"
   RuntimeLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:


### PR DESCRIPTION
My use case is primarily based on another language runtime (python) but would like to be able to also call R scripts. The build framework here only needs slight tweaks to deploy an "R only" layer that is suitable for combining with all other runtimes.

This PR currently only contains the changes to the build scripts to build and deploy the "R only" layer. Updates to the documentation and test framework can follow later if desired. 

Also note that replacing the `chown` call with `docker run --user $(id -u)` should resolve issue #52.

Thanks!